### PR TITLE
add hook.Call("CanChangeRPName")

### DIFF
--- a/gname-changer/lua/gnamechanger/name_system/sv_name_system.lua
+++ b/gname-changer/lua/gnamechanger/name_system/sv_name_system.lua
@@ -75,6 +75,12 @@ function gNameChanger:rpNameChange(len, ply)
 	
 	local firstname = net.ReadString()
 	local lastname = net.ReadString()
+	
+    	local canChangeName, reason = hook.Call("CanChangeRPName", GAMEMODE, ply, firstname .. " " .. lastname)
+    	if canChangeName == false then
+        	DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "RPname", reason or ""))
+        	return
+	end
 
 	if self:isBlacklisted(firstname, lastname) then
 		DarkRP.notify(ply, 1, 15, self.Language.nameBlacklist)	


### PR DESCRIPTION
Enables third party addons to disallow RP Name changing (disabling arrested people for instance),
also enables forbidden characters verification such as non alphanumeric ones.